### PR TITLE
bugfix/accurics_remediation_2684624791723327 - Auto Generated Pull Request From Accurics

### DIFF
--- a/ec2/main.tf
+++ b/ec2/main.tf
@@ -25,14 +25,19 @@ resource "aws_instance" "node" {
   tags = {
     Name = "TF Generated EC2"
   }
- # metadata_options {
- #   http_endpoint = "enabled"
- #   http_tokens = "required"
- # }
+  # metadata_options {
+  #   http_endpoint = "enabled"
+  #   http_tokens = "required"
+  # }
   user_data = file("${path.root}/ec2/userdata.tpl")
 
   root_block_device {
     volume_size = 10
+  }
+
+  metadata_options {
+    http_endpoint = "disabled"
+    http_tokens   = "required"
   }
 }
 


### PR DESCRIPTION
In AWS Console - 
 1. When launching a new instance in the Amazon EC2 console, select the following options on the Configure Instance Details page:
     a. Under Advanced Details, for Metadata accessible, select Enabled.
     b. For Metadata version, select V2.