### PR TITLE
bugfix/accurics_remediation_6853926315182122 - Auto Generated Pull Request From Accurics

### DIFF
--- a/ec2/main.tf
+++ b/ec2/main.tf
@@ -25,11 +25,16 @@ resource "aws_instance" "node" {
   tags = {
     Name = "TF Generated EC2"
   }
-   
+
   user_data = file("${path.root}/ec2/userdata.tpl")
 
   root_block_device {
     volume_size = 10
+  }
+
+  metadata_options {
+    http_endpoint = "disabled"
+    http_tokens   = "required"
   }
 }
 


### PR DESCRIPTION
In AWS Console - 
 1. When launching a new instance in the Amazon EC2 console, select the following options on the Configure Instance Details page:
     a. Under Advanced Details, for Metadata accessible, select Enabled.
     b. For Metadata version, select V2.