### PR TITLE
bugfix/accurics_remediation_028910754113748105 - Auto Generated Pull Request From Accurics

### DIFF
--- a/ec2/main.tf
+++ b/ec2/main.tf
@@ -35,11 +35,11 @@ resource "aws_instance" "node" {
     Name = "TF Generated EC2"
   }
   metadata_options {
-     http_endpoint = "disabled"
-     http_tokens = "required"
-   }
-   monitoring = false
-   
+    http_endpoint = "disabled"
+    http_tokens   = "required"
+  }
+  monitoring = true
+
   user_data = file("${path.root}/ec2/userdata.tpl")
 
 


### PR DESCRIPTION
In AWS Console - 
 1. When launching a new instance in the Amazon EC2 console, select the following options on the Configure Instance Details page:
     a. Under Advanced Details, for Metadata accessible, select Enabled.
     b. For Metadata version, select V2.