### PR TITLE
bugfix/accurics_remediation_026373705371070644 - Auto Generated Pull Request From Accurics

### DIFF
--- a/ec2/main.tf
+++ b/ec2/main.tf
@@ -35,11 +35,11 @@ resource "aws_instance" "node" {
     Name = "TF Generated EC2"
   }
   metadata_options {
-     http_endpoint = "disabled"
-     http_tokens = "required"
-   }
-   monitoring = false
-   
+    http_endpoint = "disabled"
+    http_tokens   = "required"
+  }
+  monitoring = false
+
   user_data = file("${path.root}/ec2/userdata.tpl")
 
 
@@ -47,6 +47,11 @@ resource "aws_instance" "node" {
     volume_size = 10
   }
 
+
+  metadata_options {
+    http_endpoint = "disabled"
+    http_tokens   = "required"
+  }
 }
 
 # Create and assosiate an Elastic IP


### PR DESCRIPTION
In AWS Console - 
1. When launching a new instance in the Amazon EC2 console, select the following options on the Configure Instance Details page:
    a. Under Advanced Details, for Metadata accessible, select Enabled.
    b. For Metadata version, select V2.

In Terraform -
1. For the aws_instance resource, set the metadata_options.http_endpoint field to disabled.
2. Set the metadata_options.http_tokens field to required.

References:
https://docs.aws.amazon.com/AWSEC2/latest/WindowsGuide/configuring-instance-metadata-service.html
https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/instance#metadata_options